### PR TITLE
Parse query url

### DIFF
--- a/plotly/js/bw-plotly-widgets.js
+++ b/plotly/js/bw-plotly-widgets.js
@@ -50,3 +50,12 @@ function getBWData(endpoint, query, callback) {
         callback(data, error);
     });
 };
+function getJsonFromUrl(query) {
+  /*var query = location.search.substr(1); */
+  var result = {};
+  query.split("&").forEach(function(part) {
+    var item = part.split("=");
+    result[item[0]] = decodeURIComponent(item[1]);
+  });
+  return result;
+}

--- a/plotly/search.html
+++ b/plotly/search.html
@@ -9,9 +9,14 @@
 <script type="text/javascript">
 function plotSearchWidget() {
 
-    var query = {
+    /*var query = {
         word: "Lincoln"
-    };
+    };*/
+    /*var parsedQuery = getJsonFromUrl(window.location.href);*/
+    var parsedQuery = getJsonFromUrl("https://analytics.hathitrust.org/blacklight/catalog?utf8=%E2%9C%93&q=Lincoln");
+    var query = new Object();
+    query.word = parsedQuery.q;
+    
     var timeSeriesOptions = {
         // Element to draw the chart in
         div: "bwSearchWidget",


### PR DESCRIPTION
parse the query term from the search url: for example, if you are on https://sharc.hathitrust.org/blacklight/catalog?utf8=✓&q=test, the chart should pull the 'test' from the q= parameter of the url, and visualize the occurrence trend for that word.
